### PR TITLE
Enable library compilation as .a instead of providing separate objects to the linker

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=All cryptographic algorithms have been optimized for 8-bit Arduino pla
 category=Other
 url=https://rweather.github.io/arduinolibs/crypto.html
 architectures=*
+dot_a_linkage=true


### PR DESCRIPTION
This enables finer optimizations by the linker when integrating this library in an executable that doesn't necessarily use all of its features. Without this flag, some statically allocated class instances, e.g. RNG, will take up space even when not used, although the executable might have been compiled with space optimization enabled and garbage collection for data sections. This reduction of memory usage can be quite significant in standard arduino platforms (e.g. 328p).